### PR TITLE
Add show_buttons option to hide controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a fork of the Blind Card by tungmeister. I needed a option to invert the
 | title_position | string | False | `top` | Set title on `top` or on `bottom` of the blind
 | invert_percentage | boolean | False | `false` | Set it to `true` to invert the direction of the blind: 0% corresponds to open and 100% to closed
 | invert_commands | boolean | False | `false` | Set it to true if you want to invert the up/down buttons to match your motors direction
+| show_buttons | boolean | False | `true` | Set to `false` to hide the up/down/stop buttons
 | blind_color | string | False | 'white' | Set blind Color e.g. `green` or hex `#00FF00`
 
 _Remark : you can also just give the entity ID (without to specify `entity:`) if you don't need to specify the other configurations._
@@ -40,6 +41,7 @@ entities:
     name: Left blind
     buttons_position: left
     title_position: bottom
+    show_buttons: false
     blind_color: '#FFD580'
   - cover.bedroom_blind
 ```

--- a/hass-blind-card.js
+++ b/hass-blind-card.js
@@ -27,6 +27,14 @@ class BlindCard extends HTMLElement {
         if (entity && entity.buttons_position) {
             buttonsPosition = entity.buttons_position.toLowerCase();
         }
+
+        let showButtons = true;
+        if (typeof _this.config.show_buttons !== 'undefined') {
+            showButtons = _this.config.show_buttons;
+        }
+        if (entity && typeof entity.show_buttons !== 'undefined') {
+            showButtons = entity.show_buttons;
+        }
         
         let titlePosition = 'top';
         if (entity && entity.title_position) {
@@ -52,21 +60,26 @@ class BlindCard extends HTMLElement {
 
         blind.className = 'sc-blind';
         blind.dataset.blind = entityId;
+        let middleFlexDirection = 'row';
+        if (showButtons) {
+            middleFlexDirection = buttonsPosition == 'right' ? 'row-reverse' : 'row';
+        }
+
         blind.innerHTML = `
           <div class="sc-blind-top" ` + (titlePosition == 'bottom' ? 'style="display:none;"' : '') + `>
             <div class="sc-blind-label">
-            
+
             </div>
             <div class="sc-blind-position">
-            
+
             </div>
           </div>
-          <div class="sc-blind-middle" style="flex-direction: ` + (buttonsPosition == 'right' ? 'row-reverse': 'row') + `;">
-            <div class="sc-blind-buttons">
+          <div class="sc-blind-middle" style="flex-direction: ` + middleFlexDirection + `;">
+            ` + (showButtons ? `<div class="sc-blind-buttons">
               <ha-icon-button class="sc-blind-button" data-command="up"><ha-icon icon="mdi:arrow-up"></ha-icon></ha-icon-button><br>
               <ha-icon-button class="sc-blind-button" data-command="stop"><ha-icon icon="mdi:stop"></ha-icon></ha-icon-button><br>
               <ha-icon-button class="sc-blind-button" data-command="down"><ha-icon icon="mdi:arrow-down"></ha-icon></ha-icon-button>
-            </div>
+            </div>` : '') + `
             <div class="sc-blind-selector">
               <div class="sc-blind-selector-picture">
                 <div class="sc-blind-selector-slide"></div>


### PR DESCRIPTION
## Summary
- allow hiding blind control buttons via new `show_buttons` option
- document the new option in README with updated example

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6867c2d62cc0832a92a603f418c7b032